### PR TITLE
add ability to have MOTORS_TO_THROTTLE on a switch

### DIFF
--- a/Silverware/src/config.h
+++ b/Silverware/src/config.h
@@ -231,6 +231,10 @@
 // throttle direct to motors for thrust measure
 // #define MOTORS_TO_THROTTLE
 
+// throttle direct to motors for thrust measure as a flight mode
+//#define MOTORS_TO_THROTTLE_MODE MULTI_CHAN_8
+
+
 // loop time in uS
 // this affects soft gyro lpf frequency if used
 #define LOOPTIME 1000

--- a/Silverware/src/control.c
+++ b/Silverware/src/control.c
@@ -663,11 +663,37 @@ thrsum = 0;
 		mix[i] = clip_ff(mix[i], i);
 		#endif
 
-		#ifdef MOTORS_TO_THROTTLE
-		mix[i] = throttle;
+		#if defined(MOTORS_TO_THROTTLE) || defined(MOTORS_TO_THROTTLE_MODE)
+		#if defined(MOTORS_TO_THROTTLE_MODE) && !defined(MOTORS_TO_THROTTLE)
+		if(aux[MOTORS_TO_THROTTLE_MODE])
+		{
+		#endif
+		switch(i)
+		{
+#define MAX(a,b) (a > b ? a : b)
+#define MIN(a,b) (a < b ? a : b)
+			case MOTOR_BL:
+				mix[i] = throttle*(1.f - (MAX(rx[ROLL], 0.f) + MAX(rx[PITCH],0.f))/2.f);
+				break;
+			case MOTOR_FL:
+				mix[i] = throttle*(1.f - (MAX(rx[ROLL], 0.f) - MIN(rx[PITCH],0.f))/2.f);
+				break;
+			case MOTOR_BR:
+				mix[i] = throttle*(1.f - (-MIN(rx[ROLL], 0.f) + MAX(rx[PITCH],0.f))/2.f);
+				break;
+			case MOTOR_FR:
+				mix[i] = throttle*(1.f - (-MIN(rx[ROLL], 0.f) - MIN(rx[PITCH],0.f))/2.f);
+				break;
+		}
+		#if defined(MOTORS_TO_THROTTLE_MODE) && !defined(MOTORS_TO_THROTTLE)
+		}
+		#endif
+
 		// flash leds in valid throttle range
+		#ifdef MOTORS_TO_THROTTLE
 		ledcommand = 1;
 		#warning "MOTORS TEST MODE"
+		#endif
 		#endif
 
 		#ifdef MOTOR_MIN_ENABLE


### PR DESCRIPTION
Add ability to have MOTORS_TO_THROTTLE on a switch.

Also add roll/pitch scaling to motor output so motors can be
tested individually using stick deflection.

We should have a contest to see who can fly the longest
in this mode!