### PR TITLE
Change order of sources and startup file

### DIFF
--- a/gcc/Makefile
+++ b/gcc/Makefile
@@ -14,7 +14,7 @@ DEFS = -DUSE_STDPERIPH_DRIVER -DSTM32F031
 STARTUP = $(topdir)/Libraries/CMSIS/Device/ST/STM32F0xx/Source/Templates/gcc_ride7/startup_stm32f030.s
 
 MCU = cortex-m0
-MCFLAGS = -mcpu=$(MCU) -g -ggdb -mthumb -fdata-sections -ffunction-sections -fsingle-precision-constant -ffast-math -nostartfiles   --specs=nano.specs -flto
+MCFLAGS = -mcpu=$(MCU) -g -ggdb -mthumb -fdata-sections -ffunction-sections -fsingle-precision-constant -ffast-math -nostartfiles --specs=nano.specs --specs=nosys.specs -flto
 
 INCLUDES = -I$(topdir)/Silverware/src/ \
 	-I$(topdir)/Libraries/CMSIS/Device/ST/STM32F0xx/Include/ \
@@ -47,10 +47,10 @@ $(TARGET).hex: $(EXECUTABLE)
 $(TARGET): $(EXECUTABLE)
 	$(CP) -O binary $^ $@
 
-$(EXECUTABLE): $(SRC) $(STARTUP)
+$(EXECUTABLE): $(STARTUP) $(SRC)
 	$(CC) $(CFLAGS) $^ -lm -o $@
 	arm-none-eabi-size $(EXECUTABLE)
-	
+
 
 clean:
 	rm -f Startup.lst $(TARGET) $(TARGET).lst $(OBJ) $(AUTOGEN) \


### PR DESCRIPTION
Due to a bug in GNU Arm Embedded Toolchain, Link Time Optimization doesn't work correct if startup file is after sources while compiling. Reversing the order doesn't harm and fixes the problem untill resolved upstream.

https://bugs.launchpad.net/gcc-arm-embedded/+bug/1747966

 Also, --specs=nosys.specs is needed to suppress new link-time errors.