### PR TITLE
Analog Aux Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For Bayang, you can use a modified version of the Bayang protocol I've made to t
 
 The Multiprotocol module uses channels 14 and 15 for these analog channels. Set the "Option/Telemetry" value for the Bayang protocol on the Taranis to 2 or 3 (2 to get only the analog channels, 3 to get both Telemetry and the analog channels).
 
-Deviation uses channels 11 and 12. Enable the Aux Analog option for the Bayang protocol.
+Deviation uses channels 13 and 14. Enable the Aux Analog option for the Bayang protocol.
 
 For both the Multiprotocol module and Deviation, Silverware will not bind with a transmitter that does not have matching options (both Telemetry and Analog Aux channels).
 

--- a/README.md
+++ b/README.md
@@ -83,3 +83,58 @@ http://sirdomsen.diskstation.me/dokuwiki/doku.php?id=start
 * new measured motor curve at 24K pwm
 * added a new way of lowering throttle below a certain voltage
 * lvc now flashes below an "uncompensated" voltage, too, just in case
+
+
+
+## brianquad Notes - Additions for Analog Aux channels
+Last major update 2018-08-19
+
+This option (controlled in config.h) adds support for Analog Aux channels to control certain pre-programmed features. These are intended to be used with a transmitter with knobs/sliders to easily alter parameters while flying. These are controlled by #define lines in config.h. Enable these features by uncommenting the "#define USE_ANALOG_AUX" line. Commenting that line disables all analog aux channels at the compiler level, meaning they do not make the built firmware bigger or slower than it was before.
+
+Initially, these features include:
+1. Analog Rate Multiplier (ANALOG_RATE_MULT)
+   - Use a tranmitter knob to control your rates to help find your sweet spot without flashing in between
+   - Set your MAX_RATE and MAX_RATE_YAW to the highest rate you might want
+   - Use the assigned knob to adjust beween 0 and 100% of that rate in a linear scale
+     - Putting the knob at its middle point will give you half of your MAX_RATE
+2. Analog Max Angle for Level mode (ANALOG_MAX_ANGLE)
+   - When in Angle/Level mode, the maximum angle the quad is allowed to tilt (controlling your max speed, etc.) is set by the LEVEL_MAX_ANGLE define
+   - When enabling ANALOG_MAX_ANGLE, the LEVEL_MAX_ANGLE define is ignored
+   - The knob controls the maximum angle from 0 to 90 degrees in a linear scale
+     - Putting the knob at its middle point will give you a maximum angle of 45 degrees
+3. PID adjustments (ANALOG_RP_P, etc.)
+   - Assigning a knob to one of these defines lets you alter that PID setting from 0.5X to 1.5X of the current setting in pid.c
+   - Each of the P, I, or D for Roll, Pitch, and Yaw can be selected in config.h, or Roll and Pitch P, I, or D can be selected together on one knob
+   - The PID adjustments can be saved, just like the classic Silverware gesture PID adjustments. To save a new value, use the Down Down Down (DDD) gesture to write the current PID values to flash (including your new one(s)) and re-center your adjusted values. This means to keep your new value after saving, you must re-center your knob/slider.
+
+These initial features are mostly meant to start a conversation on how Analog Aux channels could be used. For example, I'm sure there are better ways to do live PID adjustment with a couple of analog knobs!
+
+###How do you access/assign analog channels? What channels can be used?
+
+For Sbus and DSM, you can assign any of the channels to use as analog aux channels.
+
+For Bayang, you can use a modified version of the Bayang protocol I've made to the Multiprotocol Tx and Deviation Tx firmware that adds two 8-bit analog channels to the protocol.
+
+The Multiprotocol module uses channels 14 and 15 for these analog channels. Set the "Option/Telemetry" value for the Bayang protocol on the Taranis to 2 or 3 (2 to get only the analog channels, 3 to get both Telemetry and the analog channels).
+
+Deviation uses channels 11 and 12. Enable the Aux Analog option for the Bayang protocol.
+
+For both the Multiprotocol module and Deviation, Silverware will not bind with a transmitter that does not have matching options (both Telemetry and Analog Aux channels).
+
+These modifications can be found on the analog aux branch in my forks on GitHub (for now, you _must_ select the branch rather than master):
+	https://github.com/brianquad/DIY-Multiprotocol-TX-Module/tree/bayang-analog-aux
+	https://github.com/brianquad/deviation/tree/bayang-analog-aux
+
+####How to use Trim Switches for Silverware Analog Aux channels in Deviation
+VIRTUAL POT (Example, by Ian444):
+
+1. Say you want to assign LV (left vertical) trim switch to drive the radio channel 11 as if it were a pot, each click driving the pot in one direction or the other, using Virt3 as the intermediate link. (It could be any radio channel and use any free virtual channel.)
+
+2. Go into the TRIMS menu and set the LV trim to Virt3, so replace "whatever-is-there" with Virt3 i.e. it should look like: Virt3/step size/TRIMLV+. You can highlight "Virt3" and hit enter to get into the submenu if you need to. Set step size, trim+, trim- etc. Step size 10 gives 10 clicks up and 10 clicks down. Save it.
+
+3. Go into the MIXER menu and find Virt3, set the mixer type as "simple", Src is Virt3, curve is 1-to-1, scale is 0 and offset is 0. Save it. The output of Virt3 is -100 to +100 with 0 being centre. You can check this in the Transmitter Menu/Channel Monitor Virt3 bar graph display.
+
+4. Go into the mixer menu and find the Ch11 mixer and set this: mixer type is complex, Mixers is 1, Page is 1, Switch is none, Mux is replace, Src is Virt3, Curve is 1-to-1, scale is 100, offest is 0, and set NO TRIM instead of TRIM. You can also set limits in the Ch11 first menu if required.
+
+5. Check the radio output in the Transmitter Menu/Channel Monitor, you should see the CH11 output following the trim switch.
+

--- a/README.md
+++ b/README.md
@@ -124,15 +124,12 @@ These modifications can be found on the analog aux branch in my forks on GitHub 
 	https://github.com/brianquad/deviation/tree/bayang-analog-aux
 
 ####How to use Trim Switches for Silverware Analog Aux channels in Deviation
-VIRTUAL POT (Example, by Ian444):
+Example:
 
-1. Say you want to assign LV (left vertical) trim switch to drive the radio channel 11 as if it were a pot, each click driving the pot in one direction or the other, using Virt3 as the intermediate link. (It could be any radio channel and use any free virtual channel.)
+1. Say you want to assign the LV (left vertical) trim switch to drive the radio channel 11 as if it were a pot, each click driving the pot in one direction or the other, click up to increase and click down to decrease.
 
-2. Go into the TRIMS menu and set the LV trim to Virt3, so replace "whatever-is-there" with Virt3 i.e. it should look like: Virt3/step size/TRIMLV+. You can highlight "Virt3" and hit enter to get into the submenu if you need to. Set step size, trim+, trim- etc. Step size 10 gives 10 clicks up and 10 clicks down. Save it.
+2. Go into the Model Menu/5.Trims menu and set the LV trim to Ch11, so replace whatever-is-there (probably throttle but depends on what mode you fly) with CH11 i.e. it should look like: Ch11/step size/TRIMLV+. You can highlight throttle/whatever-is-there and hit enter to get into the submenu. Set Ch11 and set Trim Step to 10. this gives 10 clicks up and 10 clicks down for full range +100 to -100. Save it (highlight Save and press and hold the Enter button).
 
-3. Go into the MIXER menu and find Virt3, set the mixer type as "simple", Src is Virt3, curve is 1-to-1, scale is 0 and offset is 0. Save it. The output of Virt3 is -100 to +100 with 0 being centre. You can check this in the Transmitter Menu/Channel Monitor Virt3 bar graph display.
+3. Go into the MIXER menu and find CH11, set the mixer type as "simple", Src is "none", curve is 1-to-1, scale is 0 and offset is 0. Save it. 
 
-4. Go into the mixer menu and find the Ch11 mixer and set this: mixer type is complex, Mixers is 1, Page is 1, Switch is none, Mux is replace, Src is Virt3, Curve is 1-to-1, scale is 100, offest is 0, and set NO TRIM instead of TRIM. You can also set limits in the Ch11 first menu if required.
-
-5. Check the radio output in the Transmitter Menu/Channel Monitor, you should see the CH11 output following the trim switch.
-
+4. Check the radio output in the Transmitter Menu/Channel Monitor, you should see the CH11 output following the trim switch, you should see the Ch11 output going from -100 to +100 in steps of 10.

--- a/Silverware/src/config.h
+++ b/Silverware/src/config.h
@@ -25,6 +25,36 @@
 
 
 
+// *******************************ANALOG AUX CHANNELS*****************************
+// For some protocols, use Tx channels as auxiliary analog values
+// Bayang with analog aux protocol (Tx optional mode enabled in modified Multimodule and DeviationTx) has two analog channels available:
+//     Multimodule: channels 14 and 15
+//     Deviation: channels 11 and 12
+// Sbus and DSM can use analog values from any channel
+// comment to disable
+//#define USE_ANALOG_AUX
+// Select analog feature for each channel
+// comment to disable
+//#define ANALOG_RATE_MULT CHAN_11
+//#define ANALOG_MAX_ANGLE CHAN_12
+//#define ANALOG_RP_P  CHAN_11 // Adjust Roll and Pitch together
+//#define ANALOG_RP_I  CHAN_11
+//#define ANALOG_RP_D  CHAN_12
+//#define ANALOG_RP_PD CHAN_12 // Adjust Roll and Pitch P & D together
+//#define ANALOG_R_P   CHAN_11 // Adjust Roll only
+//#define ANALOG_R_I   CHAN_11
+//#define ANALOG_R_D   CHAN_12
+//#define ANALOG_P_P   CHAN_11 // Adjust Pitch only
+//#define ANALOG_P_I   CHAN_11
+//#define ANALOG_P_D   CHAN_12
+//#define ANALOG_Y_P   CHAN_11 // Adjust Yaw only
+//#define ANALOG_Y_I   CHAN_11
+//#define ANALOG_Y_D   CHAN_12
+// The following define can always be left uncommented. It just gathers all analog aux PID settings together into one define.
+#if defined USE_ANALOG_AUX && (defined ANALOG_R_P || defined ANALOG_R_I || defined ANALOG_R_D || defined ANALOG_P_P || defined ANALOG_P_I || defined ANALOG_P_D || defined ANALOG_Y_P || defined ANALOG_Y_I || defined ANALOG_Y_D || defined ANALOG_RP_P || defined ANALOG_RP_I || defined ANALOG_RP_D || defined ANALOG_RP_PD)
+    #define ANALOG_AUX_PIDS
+#endif
+
 
 // battery saver
 // do not start software if battery is too low

--- a/Silverware/src/config.h
+++ b/Silverware/src/config.h
@@ -29,27 +29,27 @@
 // For some protocols, use Tx channels as auxiliary analog values
 // Bayang with analog aux protocol (Tx optional mode enabled in modified Multimodule and DeviationTx) has two analog channels available:
 //     Multimodule: channels 14 and 15
-//     Deviation: channels 11 and 12
+//     Deviation: channels 13 and 14
 // Sbus and DSM can use analog values from any channel
 // comment to disable
 //#define USE_ANALOG_AUX
 // Select analog feature for each channel
 // comment to disable
-//#define ANALOG_RATE_MULT CHAN_11
-//#define ANALOG_MAX_ANGLE CHAN_12
-//#define ANALOG_RP_P  CHAN_11 // Adjust Roll and Pitch together
-//#define ANALOG_RP_I  CHAN_11
-//#define ANALOG_RP_D  CHAN_12
-//#define ANALOG_RP_PD CHAN_12 // Adjust Roll and Pitch P & D together
-//#define ANALOG_R_P   CHAN_11 // Adjust Roll only
-//#define ANALOG_R_I   CHAN_11
-//#define ANALOG_R_D   CHAN_12
-//#define ANALOG_P_P   CHAN_11 // Adjust Pitch only
-//#define ANALOG_P_I   CHAN_11
-//#define ANALOG_P_D   CHAN_12
-//#define ANALOG_Y_P   CHAN_11 // Adjust Yaw only
-//#define ANALOG_Y_I   CHAN_11
-//#define ANALOG_Y_D   CHAN_12
+//#define ANALOG_RATE_MULT CHAN_13
+//#define ANALOG_MAX_ANGLE CHAN_14
+//#define ANALOG_RP_P  CHAN_13 // Adjust Roll and Pitch together
+//#define ANALOG_RP_I  CHAN_13
+//#define ANALOG_RP_D  CHAN_14
+//#define ANALOG_RP_PD CHAN_14 // Adjust Roll and Pitch P & D together
+//#define ANALOG_R_P   CHAN_13 // Adjust Roll only
+//#define ANALOG_R_I   CHAN_13
+//#define ANALOG_R_D   CHAN_14
+//#define ANALOG_P_P   CHAN_13 // Adjust Pitch only
+//#define ANALOG_P_I   CHAN_13
+//#define ANALOG_P_D   CHAN_14
+//#define ANALOG_Y_P   CHAN_13 // Adjust Yaw only
+//#define ANALOG_Y_I   CHAN_13
+//#define ANALOG_Y_D   CHAN_14
 // The following define can always be left uncommented. It just gathers all analog aux PID settings together into one define.
 #if defined USE_ANALOG_AUX && (defined ANALOG_R_P || defined ANALOG_R_I || defined ANALOG_R_D || defined ANALOG_P_P || defined ANALOG_P_I || defined ANALOG_P_D || defined ANALOG_Y_P || defined ANALOG_Y_I || defined ANALOG_Y_D || defined ANALOG_RP_P || defined ANALOG_RP_I || defined ANALOG_RP_D || defined ANALOG_RP_PD)
     #define ANALOG_AUX_PIDS

--- a/Silverware/src/config.h
+++ b/Silverware/src/config.h
@@ -120,14 +120,14 @@
 // CH_EMG , CH_TO - boldclash stock tx
 
 // DEVO channels (bayang protocol)
-// DEVO_CHAN_5 - DEVO_CHAN_10
+// DEVO_CHAN_5 - DEVO_CHAN_12
 
-// Multiprotocol can use MULTI_CHAN_5 - MULTI_CHAN_10  (bayang protocol)
+// Multiprotocol can use MULTI_CHAN_5 - MULTI_CHAN_13, but not MULTI_CHAN_11  (bayang protocol)
 
 // CH_ON - on always ( all protocols)
 // CH_OFF - off always ( all protocols)
 
-// CHAN_5 - CHAN_10 - auto based on tx selection
+// CHAN_5 - CHAN_12/13 - auto based on tx selection
 
 // rates / expert mode
 #define RATES CH_EXPERT

--- a/Silverware/src/config.h
+++ b/Silverware/src/config.h
@@ -191,6 +191,11 @@
 // comment out to disable
 //#define AUTO_THROTTLE
 
+
+// Betaflight like mix scaling
+//#define MIX_SCALING
+
+
 // enable auto lower throttle near max throttle to keep control
 // mix3 works better with brushless
 // comment out to disable

--- a/Silverware/src/control.c
+++ b/Silverware/src/control.c
@@ -64,6 +64,8 @@ extern float looptime;
 
 extern char auxchange[AUXNUMBER];
 extern char aux[AUXNUMBER];
+extern float aux_analog[AUXNUMBER];
+extern char aux_analogchange[AUXNUMBER];
 
 extern int ledcommand;
 extern int ledblink;
@@ -97,7 +99,10 @@ void control( void)
 
 // rates / expert mode
 float rate_multiplier = 1.0;
-	
+
+#if (defined USE_ANALOG_AUX && defined ANALOG_RATE_MULT)
+	rate_multiplier = aux_analog[ANALOG_RATE_MULT];
+#else
 	if ( aux[RATES]  )
 	{		
 		
@@ -107,7 +112,7 @@ float rate_multiplier = 1.0;
 		rate_multiplier = LOW_RATES_MULTI;
 	}
 	// make local copy
-	
+#endif
 	
 #ifdef INVERTED_ENABLE	
     extern int pwmdir;

--- a/Silverware/src/control.c
+++ b/Silverware/src/control.c
@@ -580,6 +580,32 @@ if ( underthrottle < -0.01f) ledcommand = 1;
 }
 #endif
 
+
+#ifdef MIX_SCALING
+		float minMix = 1000.0f;
+		float maxMix = -1000.0f;
+		for (int i = 0; i < 4; ++i) {
+			if (mix[i] < minMix) minMix = mix[i];
+			if (mix[i] > maxMix) maxMix = mix[i];
+		}
+		const float mixRange = maxMix - minMix;
+		float reduceAmount = 0.0f;
+		if (mixRange > 1.0f) {
+			const float scale = 1.0f / mixRange;
+			for (int i = 0; i < 4; ++i)
+				mix[i] *= scale;
+			minMix *= scale;
+			reduceAmount = minMix;
+		} else {
+			if (maxMix > 1.0f)
+				reduceAmount = maxMix - 1.0f;
+			else if (minMix < 0.0f)
+				reduceAmount = minMix;
+		}
+		if (reduceAmount != 0.0f)
+			for (int i = 0; i < 4; ++i)
+				mix[i] -= reduceAmount;
+#endif
             
             
             

--- a/Silverware/src/defines.h
+++ b/Silverware/src/defines.h
@@ -82,6 +82,10 @@
 #define DEVO_CHAN_8 CH_VID
 #define DEVO_CHAN_9 CH_HEADFREE
 #define DEVO_CHAN_10 CH_RTH
+#define DEVO_CHAN_11 CH_TO
+#define DEVO_CHAN_12 CH_EMG
+#define DEVO_CHAN_13 CH_ANA_AUX1
+#define DEVO_CHAN_14 CH_ANA_AUX2
 
 // multimodule mapping ( taranis )
 #define MULTI_CHAN_5 CH_FLIP
@@ -90,6 +94,10 @@
 #define MULTI_CHAN_8 CH_VID
 #define MULTI_CHAN_9 CH_HEADFREE
 #define MULTI_CHAN_10 CH_INV
+#define MULTI_CHAN_12 CH_TO
+#define MULTI_CHAN_13 CH_EMG
+#define MULTI_CHAN_14 CH_ANA_AUX1
+#define MULTI_CHAN_15 CH_ANA_AUX2
 
 
 #ifdef USE_DEVO
@@ -101,6 +109,8 @@
 #define CHAN_8 CH_VID
 #define CHAN_9 CH_HEADFREE
 #define CHAN_10 CH_RTH
+#define CHAN_11 CH_TO
+#define CHAN_12 CH_EMG
 #define CHAN_13 CH_ANA_AUX1
 #define CHAN_14 CH_ANA_AUX2
 #define CHAN_ON CH_ON
@@ -115,6 +125,8 @@
 #define CHAN_8 CH_VID
 #define CHAN_9 CH_HEADFREE
 #define CHAN_10 CH_INV
+#define CHAN_12 CH_TO
+#define CHAN_13 CH_EMG
 #define CHAN_14 CH_ANA_AUX1
 #define CHAN_15 CH_ANA_AUX2
 #define CHAN_ON CH_ON

--- a/Silverware/src/defines.h
+++ b/Silverware/src/defines.h
@@ -46,6 +46,8 @@
 #define CH_AUX2 5
 #define CH_EMG 10
 #define CH_TO 11
+#define CH_ANA_AUX1 12
+#define CH_ANA_AUX2 13
 // trims numbers have to be sequential, start at CH_PIT_TRIM
 #define CH_PIT_TRIM 6
 #define CH_RLL_TRIM 7
@@ -99,6 +101,8 @@
 #define CHAN_8 CH_VID
 #define CHAN_9 CH_HEADFREE
 #define CHAN_10 CH_RTH
+#define CHAN_11 CH_ANA_AUX1
+#define CHAN_12 CH_ANA_AUX2
 #define CHAN_ON CH_ON
 #define CHAN_OFF CH_OFF
 #endif
@@ -111,6 +115,8 @@
 #define CHAN_8 CH_VID
 #define CHAN_9 CH_HEADFREE
 #define CHAN_10 CH_INV
+#define CHAN_14 CH_ANA_AUX1
+#define CHAN_15 CH_ANA_AUX2
 #define CHAN_ON CH_ON
 #define CHAN_OFF CH_OFF
 #endif

--- a/Silverware/src/defines.h
+++ b/Silverware/src/defines.h
@@ -101,8 +101,8 @@
 #define CHAN_8 CH_VID
 #define CHAN_9 CH_HEADFREE
 #define CHAN_10 CH_RTH
-#define CHAN_11 CH_ANA_AUX1
-#define CHAN_12 CH_ANA_AUX2
+#define CHAN_13 CH_ANA_AUX1
+#define CHAN_14 CH_ANA_AUX2
 #define CHAN_ON CH_ON
 #define CHAN_OFF CH_OFF
 #endif

--- a/Silverware/src/gestures.c
+++ b/Silverware/src/gestures.c
@@ -8,6 +8,7 @@
 extern int ledcommand;
 extern int ledblink;
 extern int onground;
+extern int analog_aux_pids_adjusted;
 extern char aux[AUXNUMBER];
 
 int pid_gestures_used = 0;
@@ -22,9 +23,14 @@ void gestures( void)
             if (command == GESTURE_DDD)
 		    {
 			                  
+            #ifdef ANALOG_AUX_PIDS
+                //skip accel calibration if pid gestures used or analog aux pids adjustments made
+                if ( !pid_gestures_used && !analog_aux_pids_adjusted )
+            #else
                 //skip accel calibration if pid gestures used
                 if ( !pid_gestures_used )
-                {
+            #endif
+                { 
                     gyro_cal();	// for flashing lights
                     acc_cal();                   
                 }
@@ -32,6 +38,9 @@ void gestures( void)
                 {
                     ledcommand = 1;
                     pid_gestures_used = 0;
+            #ifdef ANALOG_AUX_PIDS
+                    analog_aux_pids_adjusted = 0;
+            #endif
                 }
                 #ifdef FLASH_SAVE2
                 extern float accelcal[3];
@@ -47,9 +56,14 @@ void gestures( void)
                 extern int number_of_increments[3][3];
                 for( int i = 0 ; i < 3 ; i++)
                     for( int j = 0 ; j < 3 ; j++)
-                        number_of_increments[i][j] = 0;  
+                        number_of_increments[i][j] = 0;
                 
-                #endif
+                #ifdef USE_ANALOG_AUX
+                // reset analog aux pids array
+                pid_init();
+                #endif // USE_ANALOG_AUX
+
+                #endif // FLASH_SAVE1
 			    // reset loop time 
 			    extern unsigned long lastlooptime;
 			    lastlooptime = gettime();

--- a/Silverware/src/main.c
+++ b/Silverware/src/main.c
@@ -109,6 +109,11 @@ char aux[AUXNUMBER] = { 0 ,0 ,0 , 0 , 0 , 0};
 char lastaux[AUXNUMBER];
 // if an aux channel has just changed
 char auxchange[AUXNUMBER];
+// analog version of each aux channel
+float aux_analog[AUXNUMBER];
+float lastaux_analog[AUXNUMBER];
+// if an analog aux channel has just changed
+char aux_analogchange[AUXNUMBER];
 
 // bind / normal rx mode
 extern int rxmode;
@@ -186,7 +191,12 @@ aux[CH_AUX1] = 1;
 // load flash saved variables
     flash_load( );
 #endif
-    
+
+#ifdef USE_ANALOG_AUX
+  // saves initial pid values - after flash loading
+  pid_init();
+#endif
+    	
 	rx_init();
 
 	

--- a/Silverware/src/pid.h
+++ b/Silverware/src/pid.h
@@ -6,5 +6,6 @@ int increase_pid( void );
 int decrease_pid( void );
 void pid_precalc( void);
 void rotateErrors( void);
+void pid_init( void );
 
 

--- a/Silverware/src/rx_bayang_protocol.c
+++ b/Silverware/src/rx_bayang_protocol.c
@@ -45,6 +45,9 @@ extern float rx[4];
 extern char aux[AUXNUMBER];
 extern char lastaux[AUXNUMBER];
 extern char auxchange[AUXNUMBER];
+extern float aux_analog[AUXNUMBER];
+extern float lastaux_analog[AUXNUMBER];
+extern char aux_analogchange[AUXNUMBER];
 
 
 void writeregs ( uint8_t data[] , uint8_t size )
@@ -128,6 +131,12 @@ float packettodata( int *  data)
 	return ( ( ( data[0]&0x0003) * 256 + data[1] ) - CHANOFFSET ) * 0.001953125 ;	
 }
 
+float bytetodata(int byte)
+{
+    //return (byte - 128) * 0.0078125; // -1 to 1
+    return byte * 0.00390625; // 0 to 1
+}
+
 
 static int decodepacket( void)
 {
@@ -183,7 +192,11 @@ static char lasttrim[2];
 							
 			    aux[CH_FLIP] = (rxdata[2] & 0x08) ? 1 : 0;
 
+#ifdef USE_ANALOG_AUX
+			    aux[CH_EXPERT] = (rxdata[1] > 0x7F) ? 1 : 0;
+#else
 			    aux[CH_EXPERT] = (rxdata[1] == 0xfa) ? 1 : 0;
+#endif
 
 			    aux[CH_HEADFREE] = (rxdata[2] & 0x02) ? 1 : 0;
 
@@ -196,6 +209,23 @@ static char lasttrim[2];
 				if ( lastaux[i] != aux[i] ) auxchange[i] = 1;
 				lastaux[i] = aux[i];
 			}
+			
+#ifdef USE_ANALOG_AUX
+      // Assign all analog versions of channels based on boolean channel data
+      for (int i = 0; i < AUXNUMBER - 2; i++)
+      {
+        if (i == CH_ANA_AUX1)
+          aux_analog[CH_ANA_AUX1] = bytetodata(rxdata[1]);
+        else if (i == CH_ANA_AUX2)
+          aux_analog[CH_ANA_AUX2] = bytetodata(rxdata[13]);
+        else
+          aux_analog[i] = aux[i] ? 1.0 : 0.0;
+        aux_analogchange[i] = 0;
+        if (lastaux_analog[i] != aux_analog[i])
+          aux_analogchange[i] = 1;
+        lastaux_analog[i] = aux_analog[i];
+      }
+#endif
 			
 			return 1;	// valid packet	
 		}
@@ -270,7 +300,11 @@ void checkrx(void)
 		    {		// rx startup , bind mode
 			    xn_readpayload(rxdata, 15);
 
+#ifdef USE_ANALOG_AUX
+			    if (rxdata[0] == 162)
+#else
 			    if (rxdata[0] == 164)
+#endif
 			      {	// bind packet
 				      rfchannel[0] = rxdata[6];
 				      rfchannel[1] = rxdata[7];

--- a/Silverware/src/rx_bayang_protocol_ble.c
+++ b/Silverware/src/rx_bayang_protocol_ble.c
@@ -51,6 +51,9 @@ extern float rx[4];
 extern char aux[AUXNUMBER];
 extern char lastaux[AUXNUMBER];
 extern char auxchange[AUXNUMBER];
+extern float aux_analog[AUXNUMBER];
+extern float lastaux_analog[AUXNUMBER];
+extern char aux_analogchange[AUXNUMBER];
 
 
   char rfchannel[4];
@@ -595,6 +598,12 @@ float packettodata( int *  data)
 	return ( ( ( data[0]&0x0003) * 256 + data[1] ) - 512 ) * 0.001953125 ;	
 }
 
+float bytetodata(int byte)
+{
+    //return (byte - 128) * 0.0078125; // -1 to 1
+    return byte * 0.00390625; // 0 to 1
+}
+
 
 static int decodepacket( void)
 {
@@ -635,7 +644,11 @@ static int decodepacket( void)
 							
 			    aux[CH_FLIP] = (rxdata[2] & 0x08) ? 1 : 0;
 
+#ifdef USE_ANALOG_AUX
+			    aux[CH_EXPERT] = (rxdata[1] > 0x7F) ? 1 : 0;
+#else
 			    aux[CH_EXPERT] = (rxdata[1] == 0xfa) ? 1 : 0;
+#endif
 
 			    aux[CH_HEADFREE] = (rxdata[2] & 0x02) ? 1 : 0;
 
@@ -647,6 +660,23 @@ static int decodepacket( void)
 				if ( lastaux[i] != aux[i] ) auxchange[i] = 1;
 				lastaux[i] = aux[i];
 			}
+			
+#ifdef USE_ANALOG_AUX
+      // Assign all analog versions of channels based on boolean channel data
+      for (int i = 0; i < AUXNUMBER - 2; i++)
+      {
+        if (i == CH_ANA_AUX1)
+          aux_analog[CH_ANA_AUX1] = bytetodata(rxdata[1]);
+        else if (i == CH_ANA_AUX2)
+          aux_analog[CH_ANA_AUX2] = bytetodata(rxdata[13]);
+        else
+          aux_analog[i] = aux[i] ? 1.0 : 0.0;
+        aux_analogchange[i] = 0;
+        if (lastaux_analog[i] != aux_analog[i])
+          aux_analogchange[i] = 1;
+        lastaux_analog[i] = aux_analog[i];
+      }
+#endif
 			
 			return 1;	// valid packet	
 		}
@@ -701,7 +731,11 @@ void checkrx(void)
 		    {		// rx startup , bind mode
 			    xn_readpayload(rxdata, 15);
 
+#ifdef USE_ANALOG_AUX
+			    if (rxdata[0] == 162)
+#else
 			    if (rxdata[0] == 164)
+#endif
 			      {	// bind packet
 				      rfchannel[0] = rxdata[6];
 				      rfchannel[1] = rxdata[7];

--- a/Silverware/src/rx_bayang_protocol_telemetry.c
+++ b/Silverware/src/rx_bayang_protocol_telemetry.c
@@ -65,6 +65,9 @@ extern float rx[4];
 extern char aux[AUXNUMBER];
 extern char lastaux[AUXNUMBER];
 extern char auxchange[AUXNUMBER];
+extern float aux_analog[AUXNUMBER];
+extern float lastaux_analog[AUXNUMBER];
+extern char aux_analogchange[AUXNUMBER];
 
 
 char lasttrim[4];
@@ -384,6 +387,12 @@ float packettodata(int *data)
     return (((data[0] & 0x0003) * 256 + data[1]) - 512) * 0.001953125;
 }
 
+float bytetodata(int byte)
+{
+    //return (byte - 128) * 0.0078125; // -1 to 1
+    return byte * 0.00390625; // 0 to 1
+}
+
 
 static int decodepacket(void)
 {
@@ -431,7 +440,11 @@ static int decodepacket(void)
                       
                 aux[CH_FLIP] = (rxdata[2] & 0x08) ? 1 : 0;
 
+#ifdef USE_ANALOG_AUX
+                aux[CH_EXPERT] = (rxdata[1] > 0x7F) ? 1 : 0;
+#else
                 aux[CH_EXPERT] = (rxdata[1] == 0xfa) ? 1 : 0;
+#endif
 
                 aux[CH_HEADFREE] = (rxdata[2] & 0x02) ? 1 : 0;
 
@@ -467,6 +480,23 @@ static int decodepacket(void)
                           auxchange[i] = 1;
                       lastaux[i] = aux[i];
                   }
+
+#ifdef USE_ANALOG_AUX
+                // Assign all analog versions of channels based on boolean channel data
+                for (int i = 0; i < AUXNUMBER - 2; i++)
+                {
+                  if (i == CH_ANA_AUX1)
+                    aux_analog[CH_ANA_AUX1] = bytetodata(rxdata[1]);
+                  else if (i == CH_ANA_AUX2)
+                    aux_analog[CH_ANA_AUX2] = bytetodata(rxdata[13]);
+                  else
+                    aux_analog[i] = aux[i] ? 1.0 : 0.0;
+                  aux_analogchange[i] = 0;
+                  if (lastaux_analog[i] != aux_analog[i])
+                    aux_analogchange[i] = 1;
+                  lastaux_analog[i] = aux_analog[i];
+                }
+#endif
 
                 return 1;       // valid packet 
             }
@@ -509,9 +539,15 @@ void checkrx(void)
             {                   // rx startup , bind mode
                 xn_readpayload(rxdata, 15);
 
+#ifdef USE_ANALOG_AUX
+                if (rxdata[0] == 0xa2 || rxdata[0] == 0xa1)
+                {  // bind packet
+                        if (rxdata[0] == 0xa1)
+#else
                 if (rxdata[0] == 0xa4 || rxdata[0] == 0xa3)
-                  {             // bind packet
-                      if (rxdata[0] == 0xa3)
+                {  // bind packet
+                        if (rxdata[0] == 0xa3)
+#endif
                         {
                             telemetry_enabled = 1;
                             packet_period = PACKET_PERIOD_TELEMETRY;

--- a/Silverware/src/rx_nrf24_bayang_telemetry.c
+++ b/Silverware/src/rx_nrf24_bayang_telemetry.c
@@ -192,6 +192,9 @@ extern float rx[4];
 extern char aux[AUXNUMBER];
 extern char lastaux[AUXNUMBER];
 extern char auxchange[AUXNUMBER];
+extern float aux_analog[AUXNUMBER];
+extern float lastaux_analog[AUXNUMBER];
+extern char aux_analogchange[AUXNUMBER];
 
 
 char lasttrim[4];
@@ -431,6 +434,12 @@ float packettodata(int *data)
     return (((data[0] & 0x0003) * 256 + data[1]) - 512) * 0.001953125;
 }
 
+float bytetodata(int byte)
+{
+    //return (byte - 128) * 0.0078125; // -1 to 1
+    return byte * 0.00390625; // 0 to 1
+}
+
 
 static int decodepacket(void)
 {
@@ -478,12 +487,32 @@ static int decodepacket(void)
                       
                 aux[CH_FLIP] = (rxdata[2] & 0x08) ? 1 : 0;
 
+#ifdef USE_ANALOG_AUX
+                aux[CH_EXPERT] = (rxdata[1] > 0x7F) ? 1 : 0;
+#else
                 aux[CH_EXPERT] = (rxdata[1] == 0xfa) ? 1 : 0;
+#endif
 
                 aux[CH_HEADFREE] = (rxdata[2] & 0x02) ? 1 : 0;
 
                 aux[CH_RTH] = (rxdata[2] & 0x01) ? 1 : 0;   // rth channel
 
+#ifdef USE_ANALOG_AUX
+                // Assign all analog versions of channels based on boolean channel data
+                for (int i = 0; i < AUXNUMBER - 2; i++)
+                {
+                  if (i == CH_ANA_AUX1)
+                    aux_analog[CH_ANA_AUX1] = bytetodata(rxdata[1]);
+                  else if (i == CH_ANA_AUX2)
+                    aux_analog[CH_ANA_AUX2] = bytetodata(rxdata[13]);
+                  else
+                    aux_analog[i] = aux[i] ? 1.0 : 0.0;
+                  aux_analogchange[i] = 0;
+                  if (lastaux_analog[i] != aux_analog[i])
+                    aux_analogchange[i] = 1;
+                  lastaux_analog[i] = aux_analog[i];
+                }
+#endif
 
 
                 if ( aux[LEVELMODE] )
@@ -562,9 +591,15 @@ void checkrx(void)
                 if ( nrf24_read_xn297_payload(rxdata, 15 + 2* crc_en) )  ;
                 else return;
 
+#ifdef USE_ANALOG_AUX
+                if (rxdata[0] == 0xa2 || rxdata[0] == 0xa1)
+                {  // bind packet
+                        if (rxdata[0] == 0xa1)
+#else
                 if (rxdata[0] == 0xa4 || rxdata[0] == 0xa3)
-                  {   // bind packet
-                      if (rxdata[0] == 0xa3)
+                {  // bind packet
+                        if (rxdata[0] == 0xa3)
+#endif
                         {
                             telemetry_enabled = 1;
                             packet_period = PACKET_PERIOD_TELEMETRY;

--- a/Silverware/src/rx_sbus.c
+++ b/Silverware/src/rx_sbus.c
@@ -23,6 +23,9 @@ extern float rx[4];
 extern char aux[AUXNUMBER];
 extern char lastaux[AUXNUMBER];
 extern char auxchange[AUXNUMBER];
+extern float aux_analog[AUXNUMBER];
+extern float lastaux_analog[AUXNUMBER];
+extern char aux_analogchange[AUXNUMBER];
 int failsafe = 0;
 int rxmode = 0;
 
@@ -313,6 +316,24 @@ if ( frame_received )
 		aux[CH_EXPERT] = (channels[6] > 993) ? 1 : 0;
 		aux[CH_HEADFREE] = (channels[7] > 993) ? 1 : 0;
 		aux[CH_RTH] = (channels[8] > 993) ? 1 : 0;
+
+#ifdef USE_ANALOG_AUX
+        // Map to range 0 to 1
+        aux_analog[CH_FLIP] = (channels[5] - 173) * 0.000610128f;
+        aux_analog[CH_EXPERT] = (channels[6] - 173) * 0.000610128f;
+        aux_analog[CH_HEADFREE] = (channels[7] - 173) * 0.000610128f;
+        aux_analog[CH_RTH] = (channels[8] - 173) * 0.000610128f;
+
+        aux_analogchange[CH_FLIP] = (aux_analog[CH_FLIP] != lastaux_analog[CH_FLIP]) ? 1 : 0;
+        aux_analogchange[CH_EXPERT] = (aux_analog[CH_EXPERT] != lastaux_analog[CH_EXPERT]) ? 1 : 0;
+        aux_analogchange[CH_HEADFREE] = (aux_analog[CH_HEADFREE] != lastaux_analog[CH_HEADFREE]) ? 1 : 0;
+        aux_analogchange[CH_RTH] = (aux_analog[CH_RTH] != lastaux_analog[CH_RTH]) ? 1 : 0;
+
+        lastaux_analog[CH_FLIP] = aux_analog[CH_FLIP];
+        lastaux_analog[CH_EXPERT] = aux_analog[CH_EXPERT];
+        lastaux_analog[CH_HEADFREE] = aux_analog[CH_HEADFREE];
+        lastaux_analog[CH_RTH] = aux_analog[CH_RTH];
+#endif
         
         time_lastframe = gettime(); 
         if (sbus_stats) stat_frames_accepted++;       

--- a/Silverware/src/rx_template.c
+++ b/Silverware/src/rx_template.c
@@ -65,6 +65,9 @@ extern char aux[AUXNUMBER];
 extern char lastaux[AUXNUMBER];
 // 1 if change in aux from last value
 extern char auxchange[AUXNUMBER];
+extern float aux_analog[AUXNUMBER];
+extern float lastaux_analog[AUXNUMBER];
+extern char aux_analogchange[AUXNUMBER];
 
 int failsafe = 0;
 
@@ -202,6 +205,12 @@ float packettodata(int *data)
     return (((data[0] & 0x0003) * 256 + data[1]) - 512) * 0.001953125;
 }
 
+float bytetodata(int byte)
+{
+    //return (byte - 128) * 0.0078125; // -1 to 1
+    return byte * 0.00390625; // 0 to 1
+}
+
 
 // decode the receive data and set variables accordingly
 static int decodepacket( void)
@@ -239,11 +248,32 @@ static int decodepacket( void)
 							
 			    aux[CH_FLIP] = (rxdata[2] & 0x08) ? 1 : 0;
 
+#ifdef USE_ANALOG_AUX
+			    aux[CH_EXPERT] = (rxdata[1] > 0x7F) ? 1 : 0;
+#else
 			    aux[CH_EXPERT] = (rxdata[1] == 0xfa) ? 1 : 0;
+#endif
 
 			    aux[CH_HEADFREE] = (rxdata[2] & 0x02) ? 1 : 0;
 
 			    aux[CH_RTH] = (rxdata[2] & 0x01) ? 1 : 0;	// rth channel
+
+#ifdef USE_ANALOG_AUX
+			    // Assign all analog versions of channels based on boolean channel data
+			    for (int i = 0; i < AUXNUMBER - 2; i++)
+			    {
+            if (i == CH_ANA_AUX1)
+              aux_analog[CH_ANA_AUX1] = bytetodata(rxdata[1]);
+            else if (i == CH_ANA_AUX2)
+              aux_analog[CH_ANA_AUX2] = bytetodata(rxdata[13]);
+            else
+              aux_analog[i] = aux[i] ? 1.0 : 0.0;
+            aux_analogchange[i] = 0;
+            if (lastaux_analog[i] != aux_analog[i])
+              aux_analogchange[i] = 1;
+            lastaux_analog[i] = aux_analog[i];
+          }
+#endif
 
 
 			for ( int i = 0 ; i < AUXNUMBER - 2 ; i++)
@@ -306,7 +336,11 @@ void checkrx(void)
                 // rx bind mode , packet received
 			    xn_readpayload(rxdata, 15);
 
+#ifdef USE_ANALOG_AUX
+			    if (rxdata[0] == 162)
+#else
 			    if (rxdata[0] == 164)
+#endif
 			      {	// bind packet
 				      rfchannel[0] = rxdata[6];
 				      rfchannel[1] = rxdata[7];

--- a/Silverware/src/stickvector.c
+++ b/Silverware/src/stickvector.c
@@ -1,4 +1,5 @@
 #include "config.h"
+#include "defines.h"
 #include "util.h"
 
 #include <math.h>
@@ -9,6 +10,7 @@
 extern float GEstG[3];
 extern float Q_rsqrt( float number );
 extern char aux[];
+extern float aux_analog[];
 
 // error vector between stick position and quad orientation
 // this is the output of this function
@@ -31,13 +33,19 @@ else
 {
     last_rx[0] = rx_input[0];
     last_rx[1] = rx_input[1]; 
-	
+    
+// max angle
+#if (defined USE_ANALOG_AUX && defined ANALOG_MAX_ANGLE)
+    float max_angle = aux_analog[ANALOG_MAX_ANGLE] * 90.0f;
+#else
+    #define max_angle LEVEL_MAX_ANGLE
+#endif
 	
 float pitch, roll;
 
 	// rotate down vector to match stick position
-pitch = rx_input[1] * LEVEL_MAX_ANGLE * DEGTORAD + (float) TRIM_PITCH  * DEGTORAD;
-roll = rx_input[0] * LEVEL_MAX_ANGLE * DEGTORAD + (float) TRIM_ROLL  * DEGTORAD;
+pitch = rx_input[1] * max_angle * DEGTORAD + (float) TRIM_PITCH  * DEGTORAD;
+roll = rx_input[0] * max_angle * DEGTORAD + (float) TRIM_ROLL  * DEGTORAD;
 
 stickvector[0] = fastsin( roll );
 stickvector[1] = fastsin( pitch );


### PR DESCRIPTION
This merge adds support for "analog" aux channels to Silverware to be able to modify certain features on the fly with more than binary digital channels.

It also adds two "analog" aux channels to the Bayang protocol by taking over two of the currently-unused bytes, which requires an updated version of the Multiprotocol Module or Deviation firmware (hopefully to be merged into those projects' master branches at some point after this merge to Silverware).

More info in the discussion on RC Groups:
https://www.rcgroups.com/forums/showthread.php?3121896-Analog-Aux-Channels-for-Silverware

----------

This option (controlled in config.h) adds support for Analog Aux channels to control certain pre-programmed features. These are intended to be used with a transmitter with knobs to easily alter parameters while flying. These are controlled by #define lines in config.h.

Initially, these features include:
1. Analog Rate Multiplier (ANALOG_RATE_MULT)
- Use a transmitter knob to control your rates to help find your sweet spot without flashing in between
- Set your MAX_RATE and MAX_RATE_YAW to the highest rate you might want
- Use the assigned knob to adjust between 0 and 100% of that rate in a linear scale
- Putting the knob at its middle point will give you half of your MAX_RATE
2. Analog Max Angle for Level mode (ANALOG_MAX_ANGLE)
- When in Angle/Level mode, the maximum angle the quad is allowed to tilt (controlling your max speed, etc.) is set by the LEVEL_MAX_ANGLE define
- When enabling ANALOG_MAX_ANGLE, the LEVEL_MAX_ANGLE define is ignored
- The knob controls the maximum angle from 0 to 90 degrees in a linear scale
- Putting the knob at its middle point will give you a maximum angle of 45 degrees
3. PID adjustments (ANALOG_RP_P, etc.)
- Assigning a knob to one of these defines lets you alter that PID setting from 0.5X to 1.5X of the current setting in pid.c
- The PID adjustments are _not_ saved. To save a new value, you'll have to check where your knob it and apply that setting manually in pid.c
- Each of the P, I, or D for Roll, Pitch, and Yaw can be selected in config.h, or Roll and Pitch P, I, or D can be selected together on one knob
- The PID adjustments can be saved, just like the classic Silverware gesture PID adjustments. To save a new value, use the Down Down Down (DDD) gesture to write the current PID values to flash (including your new one(s)) and re-center your adjusted values. This means to keep your new value after saving, you must re-center your knob/slider.

These initial features are mostly meant to start a conversation on how Analog Aux channels could be used. For example, I'm sure there are better ways to do live PID adjustment with a couple of analog knobs!

**How do you access/assign analog channels? What channels can be used?**

For Sbus and DSM, you can assign any of the channels to use as analog aux channels.

For Bayang, you can use a modified version of the Bayang protocol I've made to the Multiprotocol Tx and Deviation Tx firmware that adds two 8-bit analog channels to the protocol.

The Multiprotocol module uses channels 14 and 15 for these analog channels. Set the "Option/Telemetry" value for the Bayang protocol on the Taranis to 2 or 3 (2 to get only the analog channels, 3 to get both Telemetry and the analog channels).

Deviation uses channels 13 and 14. Enable the Analog Aux option for the Bayang protocol. Find Deviation builds for several Devo and Jumper TXs attached to this post.

For both the Multiprotocol module and Deviation, Silverware will not bind with a transmitter that does not have matching options enabled/disabled (both Telemetry and Analog Aux channels).

These modifications can be found on the analog aux branch in my forks on GitHub (for now, you _must_ select the branch rather than master):
https://github.com/brianquad/DIY-Multiprotocol-TX-Module/tree/bayang-analog-aux
https://github.com/brianquad/deviation/tree/bayang-analog-aux
